### PR TITLE
Kubernetes cluster with load balancer, ingress controller with AWS CCM

### DIFF
--- a/infra/assets/ansible_k8s/k8s_create_cluster.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_create_cluster.ansible.yml
@@ -4,11 +4,69 @@
   gather_facts: false
 
   tasks:
+    - name: Create cloud configuration for AWS Cloud Controller Manager
+      become: true
+      ansible.builtin.copy:
+        dest: /etc/kubernetes/cloud-config
+        content: |
+          [Global]
+          zone=
+          vpc=VPC_ID
+          subnetId=
+          routeTableId=
+          roleArn=
+          kubernetesClusterTag=CLUSTER_NAME
+          kubernetesClusterId=CLUSTER_NAME
+          disableSecurityGroupIngress=false
+          disableStrictZoneCheck=false
+          elbSecurityGroup=
+        mode: "0755"
+
+    - name: Modify cloud configuration for AWS Cloud Controller Manager
+      become: true
+      ansible.builtin.shell: |
+        CLUSTER_NAME="{{ CLUSTER_NAME }}"
+        INTERFACE=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/)
+        VPC_ID=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$INTERFACE/vpc-id)
+        sed -i "s/VPC_ID/${VPC_ID}/g" /etc/kubernetes/cloud-config
+        sed -i "s/CLUSTER_NAME/${CLUSTER_NAME}/g" /etc/kubernetes/cloud-config
+      changed_when: false
+    - name: Create initial cluster init configuartion file
+      become: true
+      ansible.builtin.shell: |
+        kubeadm config print init-defaults > /tmp/init.yaml
+      changed_when: false
+    - name: Configure init configuration file
+      become: true
+      ansible.builtin.shell: |
+        CLUSTER_NAME="{{ CLUSTER_NAME }}"
+        sed -i 's/advertiseAddress: 1.2.3.4/advertiseAddress: 0.0.0.0/g' /tmp/init.yaml
+        HOSTNAME_FQDN=$(hostname -f)
+        sed -i "s/name: node/name: ${HOSTNAME_FQDN}/g" /tmp/init.yaml
+        sed -i "s/clusterName: kubernetes/clusterName: ${CLUSTER_NAME}/g" /tmp/init.yaml
+        AVAILABILITY_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+        INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+        PROVIDER_ID="aws:///${AVAILABILITY_ZONE}/$INSTANCE_ID"
+        sed -i "14a\
+        kubeletExtraArgs:\ncloud-provider: aws\ncloud-config: /etc/kubernetes/cloud-config\nprovider-id: ${PROVIDER_ID}\
+        " /tmp/init.yaml
+        sed -i "24a\
+        extraArgs:\ncloud-provider: aws\
+        " /tmp/init.yaml
+        sed -i "s/controllerManager: {}/controllerManager:/g" /tmp/init.yaml
+        sed -i "31a\
+        extraArgs:\ncloud-provider: aws\
+        " /tmp/init.yaml
+        sed -i "s/^.*kubeletExtraArgs:/  &/g" /tmp/init.yaml
+        sed -i "s/^.*extraArgs:/  &/g" /tmp/init.yaml
+        sed -i "s/^.*cloud-provider: aws/    &/g" /tmp/init.yaml
+        sed -i "s/^.*cloud-config:/    &/g" /tmp/init.yaml
+        sed -i "s/^.*provider-id:/    &/g" /tmp/init.yaml
+      changed_when: false
     - name: Initialize the cluster
       become: true
       ansible.builtin.shell: |
-        publicip=$(curl http://169.254.169.254/latest/meta-data/public-ipv4) \
-        && kubeadm init --pod-network-cidr=172.16.0.0/16 --apiserver-cert-extra-sans=$publicip
+        kubeadm init --config /tmp/init.yaml
       changed_when: false
     - name: Create .kube directory
       become: true

--- a/infra/assets/ansible_k8s/k8s_create_cluster.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_create_cluster.ansible.yml
@@ -96,3 +96,7 @@
         && mv kubectl-calico /usr/bin \
         && chmod +x /usr/bin/kubectl-calico
       changed_when: false
+    - name: Install Nginx ingress controller
+      ansible.builtin.shell: |
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.7.0/deploy/static/provider/aws/deploy.yaml
+      changed_when: false

--- a/infra/assets/ansible_k8s/k8s_delete_nginx_ingress_controller.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_delete_nginx_ingress_controller.ansible.yml
@@ -1,0 +1,10 @@
+# code:language=ansible
+- name: Delete nginx ingress controller on the first master node before destroying the VPC.
+  hosts: first-kube-master
+  gather_facts: false
+
+  tasks:
+    - name: Delete Nginx ingress controller
+      ansible.builtin.shell: |
+        kubectl delete -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.7.0/deploy/static/provider/aws/deploy.yaml
+      changed_when: false

--- a/infra/assets/ansible_k8s/k8s_initial_setup.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_initial_setup.ansible.yml
@@ -94,4 +94,3 @@
       ansible.builtin.systemd:
         name: containerd
         state: restarted
-   

--- a/infra/assets/ansible_k8s/k8s_join_nodes_to_k8s_cluster.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_join_nodes_to_k8s_cluster.ansible.yml
@@ -1,20 +1,73 @@
-- name: Get join command from first master node
+- name: Get IPv4 Address from first master node
   hosts: first-kube-master
   gather_facts: false
   tasks:
-    - name: Get join command
-      ansible.builtin.command: kubeadm token create --print-join-command
-      register: join_command_raw
+    - name: Get IPv4 Address
+      ansible.builtin.uri:
+        url: http://169.254.169.254/latest/meta-data/local-ipv4
+        return_content: true
+      register: first_master_ipv4_addr
       changed_when: false
-    - name: Set join command
+    - name: Set IPv4 Address
       ansible.builtin.set_fact:
-        join_command: "{{ join_command_raw.stdout_lines[0] }}"
+        first_master_ipv4_addr: "{{ first_master_ipv4_addr.content }}"
 
 - name: Join worker nodes to k8s cluster
   hosts: kube-node
   gather_facts: false
   tasks:
+    - name: Create cloud configuration for AWS Cloud Controller Manager
+      become: true
+      ansible.builtin.copy:
+        dest: /etc/kubernetes/cloud-config
+        content: |
+          [Global]
+          zone=
+          vpc=VPC_ID
+          subnetId=
+          routeTableId=
+          roleArn=
+          kubernetesClusterTag=CLUSTER_NAME
+          kubernetesClusterId=CLUSTER_NAME
+          disableSecurityGroupIngress=false
+          disableStrictZoneCheck=false
+          elbSecurityGroup=
+        mode: "0755"
+    - name: Modify cloud configuration for AWS Cloud Controller Manager
+      become: true
+      ansible.builtin.shell: |
+        CLUSTER_NAME="{{ CLUSTER_NAME }}"
+        INTERFACE=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/)
+        VPC_ID=$(curl http://169.254.169.254/latest/meta-data/network/interfaces/macs/$INTERFACE/vpc-id)
+        sed -i "s/VPC_ID/${VPC_ID}/g" /etc/kubernetes/cloud-config
+        sed -i "s/CLUSTER_NAME/${CLUSTER_NAME}/g" /etc/kubernetes/cloud-config
+      changed_when: false
+    - name: Create initial cluster join configuartion file
+      become: true
+      ansible.builtin.shell: |
+        kubeadm config print join-defaults > /tmp/join.yaml
+      changed_when: false
+    - name: Configure join configuration file
+      become: true
+      ansible.builtin.shell: |
+        CONTROL_PLANE_IP="{{ hostvars[groups['first-kube-master'].0].first_master_ipv4_addr }}"
+        HOSTNAME=$(hostname)
+        HOSTNAME_FQDN=$(hostname -f)
+        AVAILABILITY_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
+        INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+        PROVIDER_ID="aws:///${AVAILABILITY_ZONE}/$INSTANCE_ID"
+        sed -i "15a\
+        kubeletExtraArgs:\ncloud-provider: aws\ncloud-config: /etc/kubernetes/cloud-config\nprovider-id: ${PROVIDER_ID}\
+        " /tmp/join.yaml
+        sed -i "s/kube-apiserver/$CONTROL_PLANE_IP/g" /tmp/join.yaml
+        sed -i "s/$HOSTNAME/$HOSTNAME_FQDN/g" /tmp/join.yaml
+        sed -i "s/^.*kubeletExtraArgs:/  &/g" /tmp/join.yaml
+        sed -i "s/^.*cloud-provider: aws/    &/g" /tmp/join.yaml
+        sed -i "s/^.*cloud-config:/    &/g" /tmp/join.yaml
+        sed -i "s/^.*provider-id:/    &/g" /tmp/join.yaml
+      changed_when: false
     - name: Join cluster
       become: true
-      ansible.builtin.command: "{{ hostvars[groups['first-kube-master'].0].join_command }}"
+      ansible.builtin.shell: |
+        kubeadm join --config /tmp/join.yaml
       changed_when: false

--- a/infra/assets/iam_policy/ingress_controller_policy.json
+++ b/infra/assets/iam_policy/ingress_controller_policy.json
@@ -1,0 +1,241 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/infra/create_ansible_hosts.py
+++ b/infra/create_ansible_hosts.py
@@ -52,6 +52,9 @@ with open("ansible_hosts.txt", "r+") as f:
         if "[kube-master]" in line:
             for j in range(0,len(master_node_names)):
                 lines.insert(i + 1, master_node_names[j] + "\n")
+        if "[etcd]" in line:
+            for j in range(0,len(master_node_names)):
+                lines.insert(i + 1, master_node_names[j] + "\n")
     f.seek(0)
     f.truncate()
     f.writelines(lines)

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 resource "aws_iam_policy" "k8s-cluster-ingress-controller-iam-policy" {
-  name = "${var.main_suffix}-k8s-cluster-alb-ingress-controller-iam-policy"
+  name = "${var.main_suffix}-k8s-cluster-ingress-controller-iam-policy"
   policy = jsonencode(local.ingress-controller-policy-json)
 }
 

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -9,6 +9,15 @@ data "aws_iam_policy_document" "ec2-service-for-iam-role" {
 
     actions = ["sts:AssumeRole"]
   }
+}  
+
+locals {
+  ingress-controller-policy-json = jsondecode(file("${path.module}/assets/iam_policy/ingress_controller_policy.json"))
+}
+
+resource "aws_iam_policy" "k8s-cluster-ingress-controller-iam-policy" {
+  name = "${var.main_suffix}-k8s-cluster-alb-ingress-controller-iam-policy"
+  policy = jsonencode(local.ingress-controller-policy-json)
 }
 
 resource "aws_iam_role" "k8s-cluster-ec2role" {
@@ -19,6 +28,21 @@ resource "aws_iam_role" "k8s-cluster-ec2role" {
 resource "aws_iam_role_policy_attachment" "k8s-cluster-ec2role-attach-ssm-policy" {
   role = aws_iam_role.k8s-cluster-ec2role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "k8s-cluster-ec2role-attach-ec2-full-access" {
+  role = aws_iam_role.k8s-cluster-ec2role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "k8s-cluster-ec2role-attach-route53-full-access" {
+  role = aws_iam_role.k8s-cluster-ec2role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "k8s-cluster-ec2role-attach-ingress-controller-policy" {
+  role = aws_iam_role.k8s-cluster-ec2role.name
+  policy_arn = aws_iam_policy.k8s-cluster-ingress-controller-iam-policy.arn
 }
 
 resource "aws_iam_instance_profile" "k8s-cluster-ec2role-instance-profile" {

--- a/infra/k8s/master_node/master.tf
+++ b/infra/k8s/master_node/master.tf
@@ -47,8 +47,11 @@ resource "aws_instance" "master_node" {
   key_name               = var.key_name
   subnet_id              = var.public_subnet_ids[count.index % length(var.public_subnet_ids)]
   vpc_security_group_ids = [var.cluster_sg_id, aws_security_group.master_sg.id]
+  source_dest_check      = false
   tags = {
-    "Name" = "${var.cluster_prefix}-master-${count.index}"
+    "Name" : "${var.cluster_prefix}-master-${count.index}"
+    "sigs.k8s.io/cluster-api-provider-aws/role" : "control-plane"
+    "kubernetes.io/cluster/${var.cluster_prefix}" : "owned"
   }
   root_block_device {
     volume_size           = 50    # 볼륨 크기를 지정합니다.

--- a/infra/k8s/worker_node/worker.tf
+++ b/infra/k8s/worker_node/worker.tf
@@ -8,7 +8,9 @@ resource "aws_instance" "worker_node" {
   source_dest_check      = false
   vpc_security_group_ids = [var.cluster_sg_id]
   tags = {
-    "Name" = "${var.cluster_prefix}-worker-${count.index}"
+    "Name" : "${var.cluster_prefix}-worker-${count.index}"
+    "sigs.k8s.io/cluster-api-provider-aws/role" : "node"
+    "kubernetes.io/cluster/${var.cluster_prefix}" : "owned"
   }
   root_block_device {
     volume_size           = 50    # 볼륨 크기를 지정합니다.

--- a/infra/k8s_ansible.tf
+++ b/infra/k8s_ansible.tf
@@ -45,3 +45,14 @@ resource "null_resource" "join_nodes_to_k8s_cluster" {
     command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_join_nodes_to_k8s_cluster.ansible.yml --extra-vars 'CLUSTER_NAME=${var.main_suffix}-k8s'"
   }
 }
+
+resource "null_resource" "when_destroy" {
+  provisioner "local-exec" {
+    when = destroy
+    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_delete_nginx_ingress_controller.ansible.yml"
+    on_failure = continue
+  }
+  depends_on = [
+    module.k8s
+  ]
+}

--- a/infra/k8s_ansible.tf
+++ b/infra/k8s_ansible.tf
@@ -24,7 +24,7 @@ resource "null_resource" "initial_setup_for_k8s" {
     time_sleep.wait_for_connect_ssh
   ]
   provisioner "local-exec" {
-    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_initial_setup.ansible.yml "
+    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_initial_setup.ansible.yml"
   }
 }
 
@@ -33,7 +33,7 @@ resource "null_resource" "create_k8s_cluster" {
     null_resource.initial_setup_for_k8s
   ]
   provisioner "local-exec" {
-    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_create_cluster.ansible.yml"
+    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_create_cluster.ansible.yml --extra-vars 'CLUSTER_NAME=${var.main_suffix}-k8s'"
   }
 }
 
@@ -42,6 +42,6 @@ resource "null_resource" "join_nodes_to_k8s_cluster" {
     null_resource.create_k8s_cluster
   ]
   provisioner "local-exec" {
-    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_join_nodes_to_k8s_cluster.ansible.yml"
+    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_join_nodes_to_k8s_cluster.ansible.yml --extra-vars 'CLUSTER_NAME=${var.main_suffix}-k8s'"
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -15,6 +15,7 @@ module "vpc" {
   ubuntu_ami           = data.aws_ami.ubuntu_ami
   key_name             = var.key_name
   ec2_instance_profile = aws_iam_instance_profile.nat-ec2role-instance-profile.name
+  cluster_prefix        = "${var.main_suffix}-k8s"
 }
 
 module "k8s" {

--- a/infra/output.tf
+++ b/infra/output.tf
@@ -1,0 +1,7 @@
+output "master_node_ids" {
+  value = module.k8s.master_node_ids
+}
+
+output "worker_node_ids" {
+  value = module.k8s.worker_node_ids
+}

--- a/infra/vpc/variables.tf
+++ b/infra/vpc/variables.tf
@@ -7,3 +7,4 @@ variable "private_subnet_cidrs" {}
 variable "ubuntu_ami" {}
 variable "key_name" {}
 variable "ec2_instance_profile" {}
+variable "cluster_prefix" {}

--- a/infra/vpc/vpc.tf
+++ b/infra/vpc/vpc.tf
@@ -28,7 +28,9 @@ resource "aws_subnet" "public_subnets" {
   map_public_ip_on_launch = true
 
   tags = {
-    "Name" = "${var.vpc_name}-public-subnet-${substr(var.region_azs[count.index], -1, 1)}"
+    "Name" : "${var.vpc_name}-public-subnet-${substr(var.region_azs[count.index], -1, 1)}"
+    "kubernetes.io/cluster/${var.cluster_prefix}" : "shared"
+    "kubernetes.io/role/elb" : 1
   }
 }
 
@@ -41,7 +43,9 @@ resource "aws_subnet" "private_subnets" {
   enable_resource_name_dns_a_record_on_launch = true
 
   tags = {
-    "Name" = "${var.vpc_name}-private-subnet-${substr(var.region_azs[count.index], -1, 1)}"
+    "Name" : "${var.vpc_name}-private-subnet-${substr(var.region_azs[count.index], -1, 1)}"
+    "kubernetes.io/cluster/${var.cluster_prefix}" : "shared"
+    "kubernetes.io/role/internal-elb" : 1
   }
 }
 
@@ -55,7 +59,8 @@ resource "aws_route_table" "public_route_table" {
   }
 
   tags = {
-    "Name" = "${var.vpc_name}-public-route-table"
+    "Name" : "${var.vpc_name}-public-route-table"
+    "kubernetes.io/cluster/${var.cluster_prefix}" : "shared"
   }
 }
 
@@ -71,7 +76,8 @@ resource "aws_route_table" "private_route_tables" {
   }
 
   tags = {
-    "Name" = "${var.vpc_name}-private-route-table-${substr(var.region_azs[count.index], -1, 1)}"
+    "Name" : "${var.vpc_name}-private-route-table-${substr(var.region_azs[count.index], -1, 1)}"
+    "kubernetes.io/cluster/${var.cluster_prefix}" : "shared"
   }
 }
 

--- a/mlserving/bentoserve.yaml
+++ b/mlserving/bentoserve.yaml
@@ -1,27 +1,67 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bento-namespace
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: bento-namespace
   creationTimestamp: null
   labels:
-    app: bentoserve
-  name: bentoserve
+    app: bento-app
+  name: bento-app
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: bentoserve
+      app: bento-app
   strategy: {}
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: bentoserve
+        app: bento-app
     spec:
       containers:
       - image: kmubigdata/mlserving:latest
         name: pytorch-resnet50
-        args: ["bentoml", "serve"]
         resources: {}
         ports:
         - containerPort: 3000
-status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: bento-namespace
+  name: bento-service
+spec:
+  type: ClusterIP
+  selector:
+    app: bento-app
+  ports:
+    - name: http
+      port: 81
+      targetPort: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: bento-namespace
+  name: bento-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /predict
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: <YOUR URL>
+      http:
+        paths:
+        - path: /bento
+          pathType: Prefix
+          backend:
+            service:
+              name: bento-service
+              port:
+                number: 81


### PR DESCRIPTION
아래 내용이 적용되었습니다.
- AWS CCM(Cloud Controller Manager)를 이용하여 Kubernetes가 AWS Infra에 접근, 설정이 가능하도록 구성 (like EKS)
- Nginx Ingress Controller를 Kubernetes Cluster 생성 후, AWS CCM을 이용하여 자동으로 ELB(NLB)가 생성되며, Target Group까지 자동으로 연계되도록 구성.
- mlserving/bentoserve.yml을 Nginx ingress controller와 연계하여 kubectl apply 즉시 바로 배포 및 NLB를 통해 추론 서비스를 제공가능하도록 구성. (bentoml 서빙 제공 테스트 완료)
- terraform destroy 시, nginx ingress controller를 통해 생성 된 NLB를 삭제 후 terraform으로 생성된 infra를 삭제하도록 하여 문제가 없도록 함.