### PR TITLE
kube-prometheus-stack 을 이용한 모니터링 환경 구성 자동화 완료

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ calico_version="v3.25.0"
 kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/$calico_version/manifests/calico.yaml
 
 #kubectl-calico 설치
-arch="arm64"
+arch=$(dpkg --print-architecture)
 curl -L https://github.com/projectcalico/calico/releases/latest/download/calicoctl-linux-$arch -o kubectl-calico
 mv kubectl-calico /usr/bin
 chmod +x /usr/bin/kubectl-calico

--- a/infra/assets/ansible_k8s/k8s_configure_monitoring.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_configure_monitoring.ansible.yml
@@ -1,0 +1,42 @@
+# code:language=ansible
+- name: Configure monitoring in k8s cluster
+  hosts: first-kube-master
+  gather_facts: false
+  tasks:
+    - name: Add kube-promethemus helm repo
+      ansible.builtin.shell: |
+        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+        helm repo update
+      changed_when: false
+    - name: Wait for creating NLB
+      ansible.builtin.shell: |
+        set -o pipefail
+        kubectl get pods -A | grep ingress-nginx-controller | grep Running | awk '{print $4}'
+      args:
+        executable: /bin/bash
+      register: command_result
+      until: command_result.stdout == "Running"
+      retries: 30
+      delay: 10
+      changed_when: false
+    - name: Get Load balancer DNS name
+      ansible.builtin.shell: |
+        set -o pipefail
+        kubectl get svc -A | grep ingress-nginx-controller | grep LoadBalancer | awk '{print $5}'
+      register: lb_dns_address
+      changed_when: false
+      args:
+        executable: /bin/bash
+    - name: Apply kube-prometheus-stack by helm
+      ansible.builtin.shell: |
+        helm inspect values prometheus-community/kube-prometheus-stack > ./kube-prometheus-stack.values
+        helm install prometheus-community/kube-prometheus-stack \
+        --create-namespace --namespace monitoring \
+        --generate-name --values ./kube-prometheus-stack.values \
+        --set grafana.ingress.enabled=true \
+        --set grafana.ingress.ingressClassName=nginx \
+        --set grafana.ingress.paths={/} \
+        --set grafana.ingress.hosts={'{{ lb_dns_address.stdout }}'} \
+        --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+        --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false
+      changed_when: false

--- a/infra/assets/ansible_k8s/k8s_create_cluster.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_create_cluster.ansible.yml
@@ -85,18 +85,47 @@
         mode: "0750"
     - name: Install pod network (callico)
       ansible.builtin.shell: |
-        calico_version="v3.25.0" \
-        && kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/$calico_version/manifests/calico.yaml \
+        calico_version="v3.25.0" && \
+        kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/$calico_version/manifests/calico.yaml \
       changed_when: false
     - name: Install kubectl-calico
       become: true
       ansible.builtin.shell: |
-        arch="arm64" \
+        arch=$(dpkg --print-architecture) \
         && curl -L https://github.com/projectcalico/calico/releases/latest/download/calicoctl-linux-$arch -o kubectl-calico \
         && mv kubectl-calico /usr/bin \
         && chmod +x /usr/bin/kubectl-calico
       changed_when: false
     - name: Install Nginx ingress controller
       ansible.builtin.shell: |
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.7.0/deploy/static/provider/aws/deploy.yaml
+        nic_version="v1.7.0" && \
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-$nic_version/deploy/static/provider/aws/deploy.yaml
       changed_when: false
+    - name: Install helm
+      ansible.builtin.shell: |
+        set -o pipefail
+        sudo apt-get install apt-transport-https --yes
+        curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+        arch=$(dpkg --print-architecture)
+        apt_list_file="/etc/apt/sources.list.d/helm-stable-debian.list"
+        echo "deb [arch=$arch signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee $apt_list_file
+        sudo apt-get update
+        sudo apt-get install helm
+      changed_when: false
+      args:
+        executable: /bin/bash
+    # - name: Install Amazon EFS CSI Driver
+    #   ansible.builtin.shell: |
+    #     Release="1.5" \
+    #     && kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-$Release"
+    #   changed_when: false
+    # - name: Create EFS storageclass
+    #   ansible.builtin.copy:
+    #     dest: /tmp/efssc.yaml
+    #     content: |
+    #       kind: StorageClass
+    #       apiVersion: storage.k8s.io/v1
+    #       metadata:
+    #         name: efs-sc
+    #       provisioner: efs.csi.aws.com
+    #     mode: "0755"

--- a/infra/assets/ansible_k8s/k8s_delete_nginx_ingress_controller.ansible.yml
+++ b/infra/assets/ansible_k8s/k8s_delete_nginx_ingress_controller.ansible.yml
@@ -6,5 +6,6 @@
   tasks:
     - name: Delete Nginx ingress controller
       ansible.builtin.shell: |
-        kubectl delete -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.7.0/deploy/static/provider/aws/deploy.yaml
+        nic_version="v1.7.0" && \
+        kubectl delete -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-$nic_version/deploy/static/provider/aws/deploy.yaml
       changed_when: false

--- a/infra/efs/main.tf
+++ b/infra/efs/main.tf
@@ -1,0 +1,40 @@
+resource "aws_security_group" "cluster_efs_sg" {
+  ingress = [{
+    cidr_blocks      = [var.vpc.cidr_block]
+    description      = ""
+    from_port        = 2049
+    ipv6_cidr_blocks = []
+    prefix_list_ids  = []
+    protocol         = "tcp"
+    security_groups  = []
+    self             = false
+    to_port          = 2049
+  }]
+  egress = [{
+    cidr_blocks      = ["0.0.0.0/0"]
+    description      = ""
+    from_port        = 0
+    ipv6_cidr_blocks = []
+    prefix_list_ids  = []
+    protocol         = "-1"
+    security_groups  = []
+    self             = false
+    to_port          = 0
+  }]
+  vpc_id = var.vpc.id
+
+  tags = {
+    "Name" = "${var.cluster_prefix}-cluster-${var.efs_for}-efs-sg"
+  }
+}
+
+resource "aws_efs_file_system" "efs_filesystem" {
+  creation_token = "${var.cluster_prefix}-${var.efs_for}-efs"
+}
+
+resource "aws_efs_mount_target" "efs_mount_target" {
+  count = length(var.private_subnet_ids)
+  file_system_id = aws_efs_file_system.efs_filesystem.id
+  subnet_id = var.private_subnet_ids[count.index]
+  security_groups = [aws_security_group.cluster_efs_sg.id]
+}

--- a/infra/efs/output.tf
+++ b/infra/efs/output.tf
@@ -1,0 +1,3 @@
+output "efs-id" {
+  value = aws_efs_file_system.efs_filesystem.id
+}

--- a/infra/efs/variables.tf
+++ b/infra/efs/variables.tf
@@ -1,0 +1,4 @@
+variable "vpc" {}
+variable "private_subnet_ids" {}
+variable "cluster_prefix" {}
+variable "efs_for" {}

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -45,6 +45,12 @@ resource "aws_iam_role_policy_attachment" "k8s-cluster-ec2role-attach-ingress-co
   policy_arn = aws_iam_policy.k8s-cluster-ingress-controller-iam-policy.arn
 }
 
+
+# resource "aws_iam_role_policy_attachment" "k8s-cluster-ec2role-attach-EFS-client-full-access-policy" {
+#   role = aws_iam_role.k8s-cluster-ec2role.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonElasticFileSystemClientFullAccess"
+# }
+
 resource "aws_iam_instance_profile" "k8s-cluster-ec2role-instance-profile" {
   name = "${var.main_suffix}-k8s-cluster-ec2-role-instnace-profile"
   role = aws_iam_role.k8s-cluster-ec2role.name

--- a/infra/k8s/data.tf
+++ b/infra/k8s/data.tf
@@ -1,8 +1,3 @@
-data "aws_subnet" "public_subnet" {
-  count = length(var.public_subnet_ids)
-  id = var.public_subnet_ids[count.index]
-}
-
 data "aws_subnet" "private_subnet" {
   count = length(var.private_subnet_ids)
   id = var.private_subnet_ids[count.index]

--- a/infra/k8s/main.tf
+++ b/infra/k8s/main.tf
@@ -1,14 +1,25 @@
 resource "aws_security_group" "cluster_sg" {
   ingress = [{
-    cidr_blocks      = []
+    cidr_blocks      = [ var.vpc.cidr_block ]
     description      = ""
     from_port        = 0
     ipv6_cidr_blocks = []
     prefix_list_ids  = []
     protocol         = "-1"
     security_groups  = []
-    self             = true
+    self             = false
     to_port          = 0
+  },
+  {
+    cidr_blocks      = [ "0.0.0.0/0" ]
+    description      = ""
+    from_port        = 1024
+    ipv6_cidr_blocks = []
+    prefix_list_ids  = []
+    protocol         = "tcp"
+    security_groups  = []
+    self             = false
+    to_port          = 65535
   }]
   egress = [{
     cidr_blocks      = ["0.0.0.0/0"]

--- a/infra/k8s/main.tf
+++ b/infra/k8s/main.tf
@@ -34,12 +34,12 @@ module "master_node" {
   master_node_number    = var.master_node_number
   cluster_sg_id         = aws_security_group.cluster_sg.id
   vpc                   = var.vpc
-  public_subnet_ids     = var.public_subnet_ids
+  private_subnet_ids     = var.private_subnet_ids
   instance_type         = var.instance_type
   ubuntu_ami            = var.ubuntu_ami
   ec2_instance_profile  = var.ec2_instance_profile
   key_name              = var.key_name
-  public_subnet         = data.aws_subnet.public_subnet
+  private_subnet         = data.aws_subnet.private_subnet
 }
 
 module "worker_node" {

--- a/infra/k8s/master_node/master.tf
+++ b/infra/k8s/master_node/master.tf
@@ -45,7 +45,7 @@ resource "aws_instance" "master_node" {
   instance_type          = var.instance_type
   iam_instance_profile   = var.ec2_instance_profile
   key_name               = var.key_name
-  subnet_id              = var.public_subnet_ids[count.index % length(var.public_subnet_ids)]
+  subnet_id              = var.private_subnet_ids[count.index % length(var.private_subnet_ids)]
   vpc_security_group_ids = [var.cluster_sg_id, aws_security_group.master_sg.id]
   source_dest_check      = false
   tags = {

--- a/infra/k8s/master_node/variables.tf
+++ b/infra/k8s/master_node/variables.tf
@@ -3,8 +3,8 @@ variable "cluster_sg_id" {}
 variable "master_node_number" {}
 variable "instance_type" {}
 variable "vpc" {}
-variable "public_subnet_ids" {}
+variable "private_subnet_ids" {}
 variable "ubuntu_ami" {}
 variable "ec2_instance_profile" {}
 variable "key_name" {}
-variable "public_subnet" {}
+variable "private_subnet" {}

--- a/infra/k8s/variables.tf
+++ b/infra/k8s/variables.tf
@@ -1,5 +1,4 @@
 variable "vpc" {}
-variable "public_subnet_ids" {}
 variable "private_subnet_ids" {}
 variable "cluster_prefix" {}
 variable "master_node_number" {}
@@ -8,3 +7,4 @@ variable "instance_type" {}
 variable "ubuntu_ami" {}
 variable "key_name" {}
 variable "ec2_instance_profile" {}
+# variable "monitoring-efs-id" {}

--- a/infra/k8s_ansible.tf
+++ b/infra/k8s_ansible.tf
@@ -46,6 +46,15 @@ resource "null_resource" "join_nodes_to_k8s_cluster" {
   }
 }
 
+resource "null_resource" "configure_monitoring" {
+  depends_on = [
+    null_resource.join_nodes_to_k8s_cluster
+  ]
+  provisioner "local-exec" {
+    command = "ansible-playbook -i ansible_hosts.txt assets/ansible_k8s/k8s_configure_monitoring.ansible.yml"
+  }
+}
+
 resource "null_resource" "when_destroy" {
   provisioner "local-exec" {
     when = destroy

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -15,22 +15,34 @@ module "vpc" {
   ubuntu_ami           = data.aws_ami.ubuntu_ami
   key_name             = var.key_name
   ec2_instance_profile = aws_iam_instance_profile.nat-ec2role-instance-profile.name
-  cluster_prefix        = "${var.main_suffix}-k8s"
+  cluster_prefix       = "${var.main_suffix}-k8s"
+}
+
+module "efs-monitoring" {
+  source             = "./efs"
+  efs_for            = "monitoring"
+  cluster_prefix     = "${var.main_suffix}-k8s"
+  vpc                = module.vpc.vpc
+  private_subnet_ids = module.vpc.private_subnet_ids
+  depends_on = [
+    module.vpc
+  ]
 }
 
 module "k8s" {
-  source                = "./k8s"
-  cluster_prefix        = "${var.main_suffix}-k8s"
-  vpc                   = module.vpc.vpc
-  public_subnet_ids     = module.vpc.public_subnet_ids
-  private_subnet_ids    = module.vpc.private_subnet_ids
-  master_node_number    = var.master_node_number
-  worker_node_number    = var.worker_node_number
-  instance_type         = var.instance_type
-  ubuntu_ami            = data.aws_ami.ubuntu_ami
-  key_name              = var.key_name
-  ec2_instance_profile  = aws_iam_instance_profile.k8s-cluster-ec2role-instance-profile.name
+  source               = "./k8s"
+  cluster_prefix       = "${var.main_suffix}-k8s"
+  vpc                  = module.vpc.vpc
+  private_subnet_ids   = module.vpc.private_subnet_ids
+  master_node_number   = var.master_node_number
+  worker_node_number   = var.worker_node_number
+  instance_type        = var.instance_type
+  ubuntu_ami           = data.aws_ami.ubuntu_ami
+  key_name             = var.key_name
+  ec2_instance_profile = aws_iam_instance_profile.k8s-cluster-ec2role-instance-profile.name
+  monitoring-efs-id    = module.efs-monitoring.efs-id
   depends_on = [
-    module.vpc
+    module.vpc,
+    module.efs-monitoring
   ]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -18,16 +18,16 @@ module "vpc" {
   cluster_prefix       = "${var.main_suffix}-k8s"
 }
 
-module "efs-monitoring" {
-  source             = "./efs"
-  efs_for            = "monitoring"
-  cluster_prefix     = "${var.main_suffix}-k8s"
-  vpc                = module.vpc.vpc
-  private_subnet_ids = module.vpc.private_subnet_ids
-  depends_on = [
-    module.vpc
-  ]
-}
+# module "efs-monitoring" {
+#   source             = "./efs"
+#   efs_for            = "monitoring"
+#   cluster_prefix     = "${var.main_suffix}-k8s"
+#   vpc                = module.vpc.vpc
+#   private_subnet_ids = module.vpc.private_subnet_ids
+#   depends_on = [
+#     module.vpc
+#   ]
+# }
 
 module "k8s" {
   source               = "./k8s"
@@ -40,9 +40,9 @@ module "k8s" {
   ubuntu_ami           = data.aws_ami.ubuntu_ami
   key_name             = var.key_name
   ec2_instance_profile = aws_iam_instance_profile.k8s-cluster-ec2role-instance-profile.name
-  monitoring-efs-id    = module.efs-monitoring.efs-id
+  # monitoring-efs-id    = module.efs-monitoring.efs-id
   depends_on = [
     module.vpc,
-    module.efs-monitoring
+    # module.efs-monitoring
   ]
 }

--- a/mlserving/bentoserve.yaml
+++ b/mlserving/bentoserve.yaml
@@ -46,7 +46,27 @@ spec:
     app: bentoml-service
   sessionAffinity: None
   type: ClusterIP
-
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: bentoml-namespace
+  name: bentoml-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /predict
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: <YOUR URL>
+      http:
+        paths:
+        - path: /bento
+          pathType: Prefix
+          backend:
+            service:
+              name: bentoml-service
+              port:
+                number: 3000
 ---
 ### BentoService ServiceMonitor
 apiVersion: monitoring.coreos.com/v1

--- a/mlserving/bentoserve.yaml
+++ b/mlserving/bentoserve.yaml
@@ -2,27 +2,25 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: bento-namespace
+  name: bentoml-namespace
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: bento-namespace
-  creationTimestamp: null
+  namespace: bentoml-namespace
   labels:
-    app: bento-app
-  name: bento-app
+    app: bentoml-service
+  name: bentoml-service
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: bento-app
+      app: bentoml-service
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
-        app: bento-app
+        app: bentoml-service
     spec:
       containers:
       - image: kmubigdata/mlserving:latest
@@ -31,37 +29,34 @@ spec:
         ports:
         - containerPort: 3000
 ---
+### BentoService
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: bento-namespace
-  name: bento-service
+  labels:
+    app: bentoml-service
+  name: bentoml-service
+  namespace: bentoml-namespace
 spec:
-  type: ClusterIP
-  selector:
-    app: bento-app
   ports:
-    - name: http
-      port: 81
+    - name: predict
+      port: 3000
       targetPort: 3000
+  selector:
+    app: bentoml-service
+  sessionAffinity: None
+  type: ClusterIP
+
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+### BentoService ServiceMonitor
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  namespace: bento-namespace
-  name: bento-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /predict
+  name: bentoml-service
+  namespace: bentoml-namespace
 spec:
-  ingressClassName: nginx
-  rules:
-    - host: <YOUR URL>
-      http:
-        paths:
-        - path: /bento
-          pathType: Prefix
-          backend:
-            service:
-              name: bento-service
-              port:
-                number: 81
+  selector:
+    matchLabels:
+      app: bentoml-service
+  endpoints:
+  - port: predict


### PR DESCRIPTION
- kube-prometheus-stack을 이용하여 prometheus, grafana를 구성하였으며, 이를 Ansible로 자동화 하였습니다.
- bentoserve.yaml 코드를 수정하여 배포 시, 자동으로 prometheus에서 metric을 수집하도록 ServiceMonitor 관련 내용을 추가했습니다.
- Architecture에 관계 없이 자동으로 (dpkg --print-architecture) 자신에 맞는 버전을 설치하도록 변경하였습니다.
- Master node의 위치도 worker node와 동일하게 private subnet으로 변경하였습니다.

현재 bentomlserve.yaml 설치 시 자동으로 metric이 수집되어 아래와 같이 request 당 소요시간등을 수집하도록 구성할 수 있습니다.
<img width="1330" alt="image" src="https://user-images.githubusercontent.com/49053299/230731202-1b03b9c6-2e7b-4162-b2dd-c052c49589eb.png">
